### PR TITLE
Added vendor toggle, cleaned up some formatting.

### DIFF
--- a/clammy.lua
+++ b/clammy.lua
@@ -29,7 +29,7 @@ require('common');
 local const = require('constants');
 local func = require('functions')
 Imgui = require('imgui');
-local settings = require('settings');
+Settings = require('settings');
 
 
 local defaultConfig = T{
@@ -48,7 +48,7 @@ local defaultConfig = T{
 	items = const.clammingItems,
 	splitItemsBySellType = T{ true, },
 }
-Config = settings.load(defaultConfig);
+Config = Settings.load(defaultConfig);
 
 local clammy = T{
 	lowValue = Config.lowValue[1],
@@ -85,6 +85,7 @@ local clammy = T{
 	fileNameBroken = ('log_broken_%s.txt'):fmt(os.date('%Y_%m_%d__%H_%M_%S')),
 	fileDir = ('%s\\addons\\Clammy\\logs\\'):fmt(AshitaCore:GetInstallPath()),
 	playTone = false,
+	showItemSeparator = false;
 }
 clammy.filePath = clammy.fileDir .. clammy.fileName;
 clammy.filePathBroken = clammy.fileDir .. clammy.fileNameBroken;
@@ -203,10 +204,12 @@ ashita.events.register('d3d_present', 'present_cb', function ()
 		end
 
 		if (Config.showItems[1] == true) then
-			Imgui.Separator();
-
+			if clammy.showItemSeparator == true then
+				Imgui.Separator();
+			end
 			for idx,citem in ipairs(clammy.items) do
 				if (clammy.bucket[idx] ~= 0) then
+					clammy.showItemSeparator = true;
 					Imgui.Text(" - " .. clammy.items[idx].item .. " [" .. clammy.bucket[idx] .. "]");
 					Imgui.SameLine();
 					local valTxt = "(" .. func.formatInt(clammy.items[idx].gil[1] * clammy.bucket[idx]) .. ")"

--- a/constants.lua
+++ b/constants.lua
@@ -174,41 +174,41 @@ local constants = T{
     };
 
     clammingItems = {
-        { item="Bibiki slug",				weight=3,	gil=T{10}, 	vendor = true},
-        { item="Bibiki urchin", 			weight=6,	gil=T{750}, 	vendor = true},
-        { item="Broken willow fishing rod",	weight=6,	gil=T{0}, 		vendor = false},
-        { item="Coral fragment",			weight=6,	gil=T{1750}, 	vendor = true},
-        { item="Quality crab shell",	    weight=6,	gil=T{3312}, 	vendor = true}, --Note: For some reason using "High-quality" doesn't register properly, leave as "Quality" for the time being
-        { item="Crab shell",				weight=6,	gil=T{371}, 	vendor = true},  --Make sure HQ version is listed above NQ for proper registering of item
-        { item="Elshimo coconut", 			weight=6,	gil=T{44}, 	vendor = true},
-        { item="Elm log", 					weight=6,	gil=T{4000}, 	vendor = false}, --Based on estimated AH value
-        { item="Fish scales",				weight=3,	gil=T{24}, 	vendor = true},
-        { item="Goblin armor",				weight=6,	gil=T{0}, 		vendor = false},   --Based on estimated AH value
-        { item="Goblin mail", 				weight=6,	gil=T{1000}, 	vendor = false}, --Based on estimated AH value
-        { item="Goblin mask", 				weight=6,	gil=T{0}, 		vendor = false},  --Based on estimated AH value
-        { item="Hobgoblin bread", 			weight=6,	gil=T{91}, 	vendor = true},
-        { item="Hobgoblin pie", 			weight=6,	gil=T{150}, 	vendor = true},
-        { item="Igneous rock", 				weight=35,	gil=T{178}, 	vendor = true},
-        { item="Jacknife", 					weight=11,	gil=T{53}, 	vendor = true},
-        { item="Lacquer tree log", 			weight=6,	gil=T{6000}, 	vendor = false}, --Based on estimated AH value
-        { item="Maple log", 				weight=6,	gil=T{15}, 	vendor = true},
-        { item="Nebimonite", 				weight=6,	gil=T{53}, 	vendor = true},
-        { item="Oxblood", 					weight=6,	gil=T{13250}, 	vendor = true},
-        { item="Pamamas", 					weight=6,	gil=T{20}, 	vendor = true},
-        { item="Pamtam kelp", 				weight=6,	gil=T{8}, 		vendor = true},
-        { item="Pebble", 					weight=7,	gil=T{1}, 		vendor = true},
-        { item="Petrified log", 			weight=6,	gil=T{2193}, 	vendor = true}, 
-        { item="Quality pugil scales",		weight=6,	gil=T{260}, 	vendor = true},  --Note: For some reason using "High-quality" doesn't register properly, leave as "Quality" for the time being
-        { item="Pugil scales", 				weight=3,	gil=T{23}, 	vendor = true},   --Make sure HQ version is listed above NQ for proper registering of item
-        { item="Rock salt",					weight=6,	gil=T{3}, 		vendor = true},
-        { item="Seashell", 					weight=6,	gil=T{30}, 	vendor = true},
-        { item="Shall shell",				weight=6,	gil=T{300}, 	vendor = true},
-        { item="Titanictus shell", 			weight=6,	gil=T{350}, 	vendor = true},
-        { item="Tropical clam", 			weight=20,	gil=T{5100}, 	vendor = true},
-        { item="Turtle shell", 				weight=6,	gil=T{1224}, 	vendor = true},
-        { item="Uragnite shell", 			weight=6,	gil=T{1455}, 	vendor = true},
-        { item="Vongola clam", 				weight=6,	gil=T{192}, 	vendor = true},
-        { item="White sand",				weight=7,	gil=T{250}, 	vendor = true},
+        { item="Bibiki slug",				weight=3,	gil=T{10}, 	vendor = {true}},
+        { item="Bibiki urchin", 			weight=6,	gil=T{750}, 	vendor = {true}},
+        { item="Broken willow fishing rod",	weight=6,	gil=T{0}, 		vendor = {false}},
+        { item="Coral fragment",			weight=6,	gil=T{1750}, 	vendor = {true}},
+        { item="Quality crab shell",	    weight=6,	gil=T{3312}, 	vendor = {true}}, --Note: For some reason using "High-quality" doesn't register properly, leave as "Quality" for the time being
+        { item="Crab shell",				weight=6,	gil=T{371}, 	vendor = {true}},  --Make sure HQ version is listed above NQ for proper registering of item
+        { item="Elshimo coconut", 			weight=6,	gil=T{44}, 	vendor = {true}},
+        { item="Elm log", 					weight=6,	gil=T{4000}, 	vendor = {false}}, --Based on estimated AH value
+        { item="Fish scales",				weight=3,	gil=T{24}, 	vendor = {true}},
+        { item="Goblin armor",				weight=6,	gil=T{0}, 		vendor = {false}},   --Based on estimated AH value
+        { item="Goblin mail", 				weight=6,	gil=T{1000}, 	vendor = {false}}, --Based on estimated AH value
+        { item="Goblin mask", 				weight=6,	gil=T{0}, 		vendor = {false}},  --Based on estimated AH value
+        { item="Hobgoblin bread", 			weight=6,	gil=T{91}, 	vendor = {true}},
+        { item="Hobgoblin pie", 			weight=6,	gil=T{150}, 	vendor = {true}},
+        { item="Igneous rock", 				weight=35,	gil=T{178}, 	vendor = {true}},
+        { item="Jacknife", 					weight=11,	gil=T{53}, 	vendor = {true}},
+        { item="Lacquer tree log", 			weight=6,	gil=T{6000}, 	vendor = {false}}, --Based on estimated AH value
+        { item="Maple log", 				weight=6,	gil=T{15}, 	vendor = {true}},
+        { item="Nebimonite", 				weight=6,	gil=T{53}, 	vendor = {true}},
+        { item="Oxblood", 					weight=6,	gil=T{13250}, 	vendor = {true}},
+        { item="Pamamas", 					weight=6,	gil=T{20}, 	vendor = {true}},
+        { item="Pamtam kelp", 				weight=6,	gil=T{8}, 		vendor = {true}},
+        { item="Pebble", 					weight=7,	gil=T{1}, 		vendor = {true}},
+        { item="Petrified log", 			weight=6,	gil=T{2193}, 	vendor = {true}}, 
+        { item="Quality pugil scales",		weight=6,	gil=T{260}, 	vendor = {true}},  --Note: For some reason using "High-quality" doesn't register properly, leave as "Quality" for the time being
+        { item="Pugil scales", 				weight=3,	gil=T{23}, 	vendor = {true}},   --Make sure HQ version is listed above NQ for proper registering of item
+        { item="Rock salt",					weight=6,	gil=T{3}, 		vendor = {true}},
+        { item="Seashell", 					weight=6,	gil=T{30}, 	vendor = {true}},
+        { item="Shall shell",				weight=6,	gil=T{300}, 	vendor = {true}},
+        { item="Titanictus shell", 			weight=6,	gil=T{350}, 	vendor = {true}},
+        { item="Tropical clam", 			weight=20,	gil=T{5100}, 	vendor = {true}},
+        { item="Turtle shell", 				weight=6,	gil=T{1224}, 	vendor = {true}},
+        { item="Uragnite shell", 			weight=6,	gil=T{1455}, 	vendor = {true}},
+        { item="Vongola clam", 				weight=6,	gil=T{192}, 	vendor = {true}},
+        { item="White sand",				weight=7,	gil=T{250}, 	vendor = {true}},
     };
 }
 

--- a/functions.lua
+++ b/functions.lua
@@ -1,6 +1,5 @@
 local const = require("Constants");
 require('common');
-local settings = require('settings');
 local chat = require('chat');
 
 local func = T{};
@@ -10,6 +9,7 @@ func.emptyBucket = function(clammy, turnedIn, isReset)
 	clammy.weight = 0;
 	clammy.money = 0;
 	clammy.hasBucket = false
+	clammy.showItemSeparator = false;
 
 	for idx,citem in ipairs(clammy.items) do
 		clammy.bucket[idx] = 0;
@@ -117,33 +117,23 @@ func.renderEditor = function(clammy)
     if (not clammy.editorIsOpen[1]) then
         return clammy;
     end
-    Imgui.SetNextWindowSize({ 600, 450, });
-    Imgui.SetNextWindowSizeConstraints({ 600, 450, }, { FLT_MAX, FLT_MAX, });
+    Imgui.SetNextWindowSize({ 500, 450, });
+    Imgui.SetNextWindowSizeConstraints({ 0, 0, }, { FLT_MAX, FLT_MAX, });
     if (Imgui.Begin('Clammy##Config', clammy.editorIsOpen)) then
 
-        -- imgui.SameLine();
         if (Imgui.Button('Save Settings')) then
-            settings.save();
+            Settings.save();
             print(chat.header(addon.name):append(chat.message('Settings saved.')));
         end
         Imgui.SameLine();
-        if (Imgui.Button('Reload Settings')) then
-            settings.reload();
-            print(chat.header(addon.name):append(chat.message('Settings reloaded.')));
-        end
-        Imgui.SameLine();
         if (Imgui.Button('Reset Settings')) then
-            settings.reset();
+            Settings.reset();
             print(chat.header(addon.name):append(chat.message('Settings reset to defaults.')));
         end
         Imgui.SameLine();
-        if (Imgui.Button('Clear Session')) then
+        if (Imgui.Button('Reset Session')) then
             clammy = func.resetSession(clammy);
             print(chat.header(addon.name):append(chat.message('Reset session.')));
-        end
-        Imgui.SameLine();
-        if (Imgui.Button('Reload Clammy')) then
-            print('/addon reload clammy');
         end
 
         Imgui.Separator();
@@ -186,53 +176,166 @@ func.renderGeneralConfig = function()
         Imgui.ShowHelp('Toggles if the weight in the window should be based on value of the bucket.');
         Imgui.Checkbox('No clammy outside the bay', Config.hideInDifferentZone);
         Imgui.ShowHelp('Toggles if the clammy window should hide if not in Bibiki Bay.')
+		Imgui.SetNextItemWidth(100);
 		Imgui.InputInt('High value amount', Config.highValue);
 		Imgui.ShowHelp('Indicates when bucket weight turns red at less than 20 ponze of space remaining.');
+		Imgui.SetNextItemWidth(100);
 		Imgui.InputInt('Medium value amount', Config.midValue);
 		Imgui.ShowHelp('Indicates when bucket weight turns red at less than 11 ponze of space remaining.');
+		Imgui.SetNextItemWidth(100);
 		Imgui.InputInt('Low value amount', Config.lowValue);
 		Imgui.ShowHelp('Indicates when bucket weight turns red at less than 7 ponze of space remaining.');
     Imgui.EndChild();
 end
 
 func.renderItemListConfig = function()
-    Imgui.Text('Item Settings');
-    Imgui.BeginChild("settings_general", {0, 320, }, true);
-        Imgui.InputInt(Config.items[1].item, Config.items[1].gil);
-        Imgui.InputInt(Config.items[2].item, Config.items[2].gil);
-        Imgui.InputInt(Config.items[3].item, Config.items[3].gil);
-        Imgui.InputInt(Config.items[4].item, Config.items[4].gil);
-        Imgui.InputInt(Config.items[5].item, Config.items[5].gil);
-        Imgui.InputInt(Config.items[6].item, Config.items[6].gil);
-        Imgui.InputInt(Config.items[7].item, Config.items[7].gil);
-        Imgui.InputInt(Config.items[8].item, Config.items[8].gil);
-        Imgui.InputInt(Config.items[9].item, Config.items[9].gil);
-        Imgui.InputInt(Config.items[10].item, Config.items[10].gil);
-        Imgui.InputInt(Config.items[11].item, Config.items[11].gil);
-        Imgui.InputInt(Config.items[12].item, Config.items[12].gil);
-        Imgui.InputInt(Config.items[13].item, Config.items[13].gil);
-        Imgui.InputInt(Config.items[14].item, Config.items[14].gil);
-        Imgui.InputInt(Config.items[15].item, Config.items[15].gil);
-        Imgui.InputInt(Config.items[16].item, Config.items[16].gil);
-        Imgui.InputInt(Config.items[17].item, Config.items[17].gil);
-        Imgui.InputInt(Config.items[18].item, Config.items[18].gil);
-        Imgui.InputInt(Config.items[19].item, Config.items[19].gil);
-        Imgui.InputInt(Config.items[20].item, Config.items[20].gil);
-        Imgui.InputInt(Config.items[21].item, Config.items[21].gil);
-        Imgui.InputInt(Config.items[22].item, Config.items[22].gil);
-        Imgui.InputInt(Config.items[23].item, Config.items[23].gil);
-        Imgui.InputInt(Config.items[24].item, Config.items[24].gil);
-        Imgui.InputInt(Config.items[25].item, Config.items[25].gil);
-        Imgui.InputInt(Config.items[26].item, Config.items[26].gil);
-        Imgui.InputInt(Config.items[27].item, Config.items[27].gil);
-        Imgui.InputInt(Config.items[28].item, Config.items[28].gil);
-        Imgui.InputInt(Config.items[29].item, Config.items[29].gil);
-        Imgui.InputInt(Config.items[30].item, Config.items[30].gil);
-        Imgui.InputInt(Config.items[31].item, Config.items[31].gil);
-        Imgui.InputInt(Config.items[32].item, Config.items[32].gil);
-        Imgui.InputInt(Config.items[33].item, Config.items[33].gil);
-        Imgui.InputInt(Config.items[34].item, Config.items[34].gil);
-        Imgui.InputInt(Config.items[35].item, Config.items[35].gil);
+    Imgui.BeginChild("settings_items", {0, 320, }, true);
+		Imgui.Text('    Item Value:');
+		Imgui.ShowHelp('Set sale price of item.');
+		Imgui.SameLine();
+		Imgui.Text('                Vendor:')
+		Imgui.ShowHelp('Check whether to sell to a vendor or the AH.');
+		Imgui.Separator();
+		Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[1].item .. '      ', Config.items[1].gil); -- Bibiki slug      -- 17
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[1].item, Config.items[1].vendor);
+		Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[2].item .. '    ', Config.items[2].gil); -- Bibiki urchin
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[2].item, Config.items[2].vendor);
+		Imgui.SetNextItemWidth(100);
+        Imgui.InputInt('Bkn. willow rod  ', Config.items[3].gil); -- Broken willow fishing rod
+		Imgui.SameLine();
+		Imgui.Checkbox('Bkn. willow rod', Config.items[3].vendor, 'Bkn. willow rod');
+		Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[4].item .. '   ', Config.items[4].gil); -- Coral fragment
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[4].item, Config.items[4].vendor, Config.items[4].item);
+		Imgui.SetNextItemWidth(100);
+        Imgui.InputInt('H.Q. crab shell  ', Config.items[5].gil); -- Quality crab shell
+        Imgui.SameLine();
+		Imgui.Checkbox(Config.items[5].item, Config.items[5].vendor, 'H.Q. crab shell');
+		Imgui.SetNextItemWidth(100);
+		Imgui.InputInt(Config.items[6].item .. '       ', Config.items[6].gil); -- Crab shell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[6].item, Config.items[6].vendor, Config.items[6].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[7].item .. '  ', Config.items[7].gil); -- Elshimo coconut (Not in Horizon)
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[7].item, Config.items[7].vendor, Config.items[7].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[8].item .. '          ', Config.items[8].gil); -- Elm log
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[8].item, Config.items[8].vendor, Config.items[8].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[9].item .. '      ', Config.items[9].gil); -- Fish scales
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[9].item, Config.items[9].vendor, Config.items[9].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[10].item .. '     ', Config.items[10].gil); -- Goblin armor
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[10].item, Config.items[10].vendor, Config.items[10].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[11].item .. '      ', Config.items[11].gil); -- Goblin mail
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[11].item, Config.items[11].vendor, Config.items[11].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[12].item .. '      ', Config.items[12].gil); -- Goblin mask
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[12].item, Config.items[12].vendor, Config.items[12].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[13].item .. '  ', Config.items[13].gil); -- Hobgoblin bread
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[13].item, Config.items[13].vendor, Config.items[13].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[14].item .. '    ', Config.items[14].gil); -- Hobgoblin pie
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[14].item, Config.items[14].vendor, Config.items[14].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[15].item .. '     ', Config.items[15].gil); -- Igneous rock (Not on Horizon)
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[15].item, Config.items[15].vendor, Config.items[15].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[16].item .. '         ', Config.items[16].gil); -- Jacknife
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[16].item, Config.items[16].vendor, Config.items[16].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[17].item .. ' ', Config.items[17].gil); -- Lacquer tree log
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[17].item, Config.items[17].vendor, Config.items[17].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[18].item .. '        ', Config.items[18].gil); -- Maple log
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[18].item, Config.items[18].vendor, Config.items[18].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[19].item .. '       ', Config.items[19].gil); -- Nebimonite
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[19].item, Config.items[19].vendor, Config.items[19].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[20].item .. '          ', Config.items[20].gil); -- Oxblood
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[20].item, Config.items[20].vendor, Config.items[20].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[21].item .. '          ', Config.items[21].gil); -- Pamamas
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[21].item, Config.items[21].vendor, Config.items[21].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[22].item .. '      ', Config.items[22].gil); -- Pamtam kelp
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[22].item, Config.items[22].vendor, Config.items[22].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[23].item .. '           ', Config.items[23].gil); -- Pebble
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[23].item, Config.items[23].vendor, Config.items[23].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[24].item .. '    ', Config.items[24].gil); -- Petrified log
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[24].item, Config.items[24].vendor, Config.items[24].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt('H.Q. pugil Scls. ', Config.items[25].gil); -- Quality pugil scales
+		Imgui.SameLine();
+		Imgui.Checkbox('H.Q. pugil Scls.', Config.items[25].vendor, Config.items[25].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[26].item .. '     ', Config.items[26].gil); -- Pugil scales
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[26].item, Config.items[26].vendor, Config.items[26].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[27].item .. '        ', Config.items[27].gil); -- Rock salt (Not on Horizon)
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[27].item, Config.items[27].vendor, Config.items[27].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[28].item .. '         ', Config.items[28].gil); -- Seashell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[28].item, Config.items[28].vendor, Config.items[28].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[29].item .. '      ', Config.items[29].gil); -- Shall shell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[29].item, Config.items[29].vendor, Config.items[29].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[30].item .. ' ', Config.items[30].gil); -- Titanictus shell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[30].item, Config.items[30].vendor, Config.items[30].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[31].item .. '    ', Config.items[31].gil); -- Tropical clam
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[31].item, Config.items[31].vendor, Config.items[31].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[32].item .. '     ', Config.items[32].gil); -- Turtle shell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[32].item, Config.items[32].vendor, Config.items[32].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[33].item .. '   ', Config.items[33].gil); -- Uragnite shell
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[33].item, Config.items[33].vendor, Config.items[33].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[34].item .. '     ', Config.items[34].gil); -- Vongola clam
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[34].item, Config.items[34].vendor, Config.items[34].item);
+        Imgui.SetNextItemWidth(100);
+        Imgui.InputInt(Config.items[35].item .. '       ', Config.items[35].gil); -- White sand
+		Imgui.SameLine();
+		Imgui.Checkbox(Config.items[35].item, Config.items[35].vendor, Config.items[35].item);
     Imgui.EndChild();
 end
 
@@ -282,7 +385,7 @@ func.toggleShowValue = function(shouldShowValue)
 		Config.showValue[1] = false;
 		print(chat.header(addon.name):append(chat.message('Show value turned off.')));
 	end
-	settings.save();
+	Settings.save();
 end
 
 func.toggleLogAllResults = function(shouldLogAllResults)
@@ -296,7 +399,7 @@ func.toggleLogAllResults = function(shouldLogAllResults)
 		print(chat.header(addon.name):append(chat.message('Logging only items actually received.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.toggleShowSessionInfo = function(shouldShowSessionInfo)
@@ -308,7 +411,7 @@ func.toggleShowSessionInfo = function(shouldShowSessionInfo)
 		print(chat.header(addon.name):append(chat.message('Not showing gil earned and gil per hour.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.toggleUseBucketValueForWeightColor = function(shouldUseBucketValueForWeightColor)
@@ -323,7 +426,7 @@ func.toggleUseBucketValueForWeightColor = function(shouldUseBucketValueForWeight
 		print(chat.header(addon.name):append(chat.message('Bucket weight color based on odds of breaking bucket.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.setWeightValues = function(weightLevel, value)
@@ -347,7 +450,7 @@ func.setWeightValues = function(weightLevel, value)
 		print(chat.header(addon.name):append(chat.message('Invalid setweightvalues parameter passed.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.toggleShowItems = function(shouldShowItems)
@@ -361,7 +464,7 @@ func.toggleShowItems = function(shouldShowItems)
 		print(chat.header(addon.name):append(chat.message('Show items turned off.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.toggleLogItems = function(shouldLogItems)
@@ -373,7 +476,7 @@ func.toggleLogItems = function(shouldLogItems)
 		print(chat.header(addon.name):append(chat.message('Logging items turned off.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.togglePlayTone = function(shouldPlayTone)
@@ -385,7 +488,7 @@ func.togglePlayTone = function(shouldPlayTone)
 		print(chat.header(addon.name):append(chat.message('Play tone turned off.')));
 	end
 
-	settings.save();
+	Settings.save();
 end
 
 func.toggleTrackMoon = function(shouldShowMoon)
@@ -397,7 +500,7 @@ func.toggleTrackMoon = function(shouldShowMoon)
         print(chat.header(addon.name):append(chat.message('Display Moon turned off.')));
     end
 
-    settings.save();
+    Settings.save();
 end
 
 func.getTimestamp = function()


### PR DESCRIPTION
* Added new vendor toggle in item screen:
<img width="503" height="454" alt="image" src="https://github.com/user-attachments/assets/f6b71586-ce2b-4eed-b653-46041725ba0a" />

* Shrank all price boxes to be 100 gil:
<img width="503" height="451" alt="image" src="https://github.com/user-attachments/assets/6c3ff6f7-d74d-48dc-995a-036098297a46" />

* Removed unused buttons, "Reload Settings" and "Reload Addon" and renamed "Clear Session" to "Reset Session" for clarity.
* Removed Separator in between current moon phase and list of items in bucket when no items are currently in bucket.